### PR TITLE
changed type of FSTNode.parent to FSTNonTerminal.

### DIFF
--- a/fstcomp/composer/FSTGenComposer.java
+++ b/fstcomp/composer/FSTGenComposer.java
@@ -341,7 +341,7 @@ public class FSTGenComposer extends FSTGenProcessor {
 	}
 
 	public FSTNode compose(FSTNode nodeA, FSTNode nodeB,
-			FSTNode compParent) {
+			FSTNonTerminal compParent) {
 
 		if (nodeA.compatibleWith(nodeB)) {
 			FSTNode compNode = nodeA.getShallowClone();

--- a/fstcomp/modification/content/ParseableTest.java
+++ b/fstcomp/modification/content/ParseableTest.java
@@ -50,7 +50,7 @@ public class ParseableTest {
 	CSharpMethod csNew = new CSharpMethod(
 		"public int method(){original();something();}");
 
-	FSTNode par = new FSTNonTerminal("nonterminal", "parent");
+	FSTNonTerminal par = new FSTNonTerminal("nonterminal", "parent");
 
 	System.out.println((new FSTGenComposer())
 		.compose(csNew.getFST(), csOldFST, par).getParent());

--- a/fstgen/src/de/ovgu/cide/fstgen/ast/FSTNode.java
+++ b/fstgen/src/de/ovgu/cide/fstgen/ast/FSTNode.java
@@ -3,7 +3,7 @@ package de.ovgu.cide.fstgen.ast;
 public abstract class FSTNode {
 	private String name;
 	private String type;
-	private FSTNode parent = null;
+	private FSTNonTerminal parent = null;
 	public int index = -1;
 
 	protected FSTNode(String type, String name) {
@@ -27,11 +27,11 @@ public abstract class FSTNode {
 		return type;
 	}
 
-	public void setParent(FSTNode parent) {
+	public void setParent(FSTNonTerminal parent) {
 		this.parent = parent;
 	}
 
-	public FSTNode getParent() {
+	public FSTNonTerminal getParent() {
 		return parent;
 	}
 	

--- a/fstmerge/merger/FSTGenMerger.java
+++ b/fstmerge/merger/FSTGenMerger.java
@@ -201,7 +201,7 @@ public class FSTGenMerger extends FSTGenProcessor {
 		return merge(nodeA, nodeB, null, firstPass);
 	}
 
-	public static FSTNode merge(FSTNode nodeA, FSTNode nodeB, FSTNode compParent, boolean firstPass) {
+	public static FSTNode merge(FSTNode nodeA, FSTNode nodeB, FSTNonTerminal compParent, boolean firstPass) {
 		
 		//System.err.println("nodeA: " + nodeA.getName() + " index: " + nodeA.index);
 		//System.err.println("nodeB: " + nodeB.getName() + " index: " + nodeB.index);


### PR DESCRIPTION
A parent must always be a non-Terminal and this makes many casts redundant.
I found no situation where the object passed to setParent(..) might not be a FSTNonTerminal.
