### PR TITLE
Fix missing feature name bug during metaproduct generation

### DIFF
--- a/fstcomp/composer/FSTGenComposer.java
+++ b/fstcomp/composer/FSTGenComposer.java
@@ -283,7 +283,7 @@ public class FSTGenComposer extends FSTGenProcessor {
 	 * Set the original feature of FSTTerminals, because the tree is composed and this
 	 * information would be lost.
 	 */
-	private void setOriginalFeatureName(FSTNonTerminal node, String feature) {
+	protected void setOriginalFeatureName(FSTNonTerminal node, String feature) {
 		if (node.getType().equals("Feature")) {
 			feature = node.getName();
 		}

--- a/fstcomp/composer/FSTGenComposerExtension.java
+++ b/fstcomp/composer/FSTGenComposerExtension.java
@@ -181,6 +181,7 @@ public class FSTGenComposerExtension extends FSTGenComposer {
 			if (metaproduct) {
 				preProcessSubtree(current);
 			}
+			setOriginalFeatureName((FSTNonTerminal) current, "");
 			if (composed != null) {
 				composed = compose(current, composed);
 			} else


### PR DESCRIPTION
In the metaproduct, some method names include the names of the feature, the methods are originally defined in. These feature names are set incorrectly to `null`. The linked screenshot shows the bug with the metaproduct for BankAccount SPL from http://spl2go.cs.ovgu.de/projects/54. This change fixes this bug.
Edit: Screenshot upload does not seem to be working -> https://www.dropbox.com/s/2zku3ncbp7wnmkx/FeatureHouseMetaproductBug.png?dl=0
