### PR TITLE
Update to the approximated c grammar

### DIFF
--- a/fstgen/.settings/org.eclipse.jdt.core.prefs
+++ b/fstgen/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,11 @@
-#Mon Apr 20 17:10:42 CEST 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.7

--- a/fstgen/test/Test.c
+++ b/fstgen/test/Test.c
@@ -1,8 +1,13 @@
-#include <stdio.h>
+#ifdef HAVE_FTRUNCATE
 
-struct X {
-	int x;
-	int z;
-};
+int __db_find_free(dbc, type, size, bstart, freep)
+	DBC *dbc;
+	u_int32_t type;
+	u_int32_t size;
+	db_pgno_t bstart, *freep;
+{
 
-int main( void ) { printf( "Hallo!\n" ); }
+
+	return (ret);
+}
+#endif

--- a/fstgen/test/build.xml
+++ b/fstgen/test/build.xml
@@ -7,7 +7,7 @@
 
      ckaestne
      ====================================================================== -->
-<project name="test_fstgen" default="testAsmetaL">
+<project name="test_fstgen" default="testC">
 	<echo>${java.class.path}</echo>
 	<eclipse.convertPath resourcePath="fstgen" property="fstgen_dir" />
 	<eclipse.convertPath resourcePath="CIDE2_ast/bin" property="ast_dir" />

--- a/fstgen/test/capprox_fst.gcide
+++ b/fstgen/test/capprox_fst.gcide
@@ -414,7 +414,7 @@ CodeUnit_InBlock:
 	Statement :: Stmt;	
 
 
-@FSTTerminal(name="{TOSTRING}")		
+@FSTTerminal(name="{AnyStmtToken}^.")
 Statement:
 	(AnyStmtToken)*  ";" @!;
 	
@@ -454,31 +454,45 @@ PPDefineStatement:
 	LL(2) "#" "define" JAVATOKEN(findLineEnd)@! |
 	LL(2) "#" "undef" JAVATOKEN(findLineEnd)@!;
 
-@FSTExportName("{IfDefLine}")
+@FSTExportName("{IfDefTopLevelBlock}")
 @FSTNonTerminal
 PPIfDef_TopLevel:
-	IfDefLine  @+
-	Sequence_CodeUnit_TopLevel
+	 IfDefTopLevelBlock  @+	
 	(LL(2) IfElseIf_TopLevel)*
-	[ LL(2) @- "#" "else" @+! Sequence_CodeUnit_TopLevel ] 
-	@- "#" "endif" @!;
+	[ LL(2) @- "#" "else" @+! IfDefBlock ]
+	@- "#endif" @!;
 
+@FSTExportName("{IfDefBlockLevelBlock}")
 PPIfDef_BlockLevel:
-	IfDefLine @+
-	Sequence_CodeUnit_InBlock
+	IfDefBlockLevelBlock @+	
 	(LL(2) IfElseIf_BlockLevel)*
-	[ LL(2)@- "#" "else" @+! Sequence_CodeUnit_InBlock @!] 
+	[ LL(2)@- "#" "else" @+! IfDefBlock @!]
 	@-"#" "endif"@!;
 
 //@FSTExportName("{TOSTRING}")
 PPOtherIgnore:
 	"line" | "pragma" |"error";
 	
-@FSTExportName("{TOSTRING}")
-//@FSTTerminal(compose="CMethodOverriding")	
-IfDefLine:
-	LL(2) "#" "ifdef" <IDENTIFIER> @!| LL(2)  "#" "ifndef" <IDENTIFIER>@! | "#" "if" JAVATOKEN(findLineEnd)@!;
+
+@FSTNonTerminal(name="{IfDefHeader}-{IfDefBlock}")
+IfDefTopLevelBlock:
+	LL(2) IfDefHeader IfDefBlock @! 
+	| LL(2)  "#" "ifndef" Id@! IfDefBlock 
+	| "#" "if" JAVATOKEN(findLineEnd)@! IfDefBlock;
 	
+@FSTExportName("{Id}")
+IfDefHeader:
+	"#ifdef" Id;
+
+@FSTNonTerminal(name="{CodeUnit_TopLevel}")
+IfDefBlock:
+	(LL(2) CodeUnit_TopLevel @!)*;
+	
+@FSTExportName("{Id}")
+@FSTNonTerminal
+IfDefBlockLevelBlock:
+	LL(2) "#ifdef" Id Sequence_CodeUnit_InBlock @! | LL(2)  "#" "ifndef" Id@! Sequence_CodeUnit_InBlock | "#" "if" JAVATOKEN(findLineEnd)@! Sequence_CodeUnit_InBlock;
+
 IfElseIf:
 	LL(2) "#" "elif" <NONE> | "#" "elsif"<NONE>;
 	
@@ -544,9 +558,14 @@ Cast:
 	"(" FunctionReturnType ")";
 	
 AnyTypeDefToken: LL(1) "{" <NONE> | "}" | AnyStmtToken;
-	
+
+@FSTExportName("{TOSTRING}")
+StarSign:
+	"*";
+
+@FSTExportName("{<IDENTIFIER>}")
 AnyStmtToken:  <IDENTIFIER> | <LITERAL>  | <OTHER> | "," | "|" | "<" | ">" | "(" | ")" | 
-	Block | "if" | "else" | "for" | "while" | LL(3) EnumBlock | "enum" | "*" |
+	Block | "if" | "else" | "for" | "while" | LL(3) EnumBlock | "enum" | StarSign  |
 	LL("\"=\" [Cast()]\"{\"") BlockAssignment | "=" | ":"  
 	| Modifier  
 	|  "ifdef" | "ifndef" | "define" | "include" | "elif" | "elsif" | PPOtherIgnore

--- a/fstgen/test/capprox_fst.gcide
+++ b/fstgen/test/capprox_fst.gcide
@@ -387,7 +387,7 @@ Sequence_CodeUnit_TopLevel:
 CodeUnit_TopLevel:
 	@FSTTerminal(name="{PPIncludeStatement}") LL(2) PPIncludeStatement :: Include | 
 	@FSTTerminal(name="{PPDefineStatement}") LL(2) PPDefineStatement :: Define | 
-	@FSTTerminal(name="{PPIfDef_TopLevel}") LL(2) PPIfDef_TopLevel :: IfDefTL |
+	@FSTNonTerminal(name="{PPIfDef_TopLevel}") LL(2) PPIfDef_TopLevel :: IfDefTL|
 	@FSTTerminal(name="{PPOtherIgnore}") LL(2) "#" PPOtherIgnore JAVATOKEN(findLineEnd) @! :: Preprocessor | 
 	@FSTTerminal(name="{Function}",compose="JavaMethodOverriding") LL("FunctionHeader()") Function :: Func | 
 	@FSTTerminal(name="{TypeDef}") TypeDef :: TypeDef_ |
@@ -396,7 +396,8 @@ CodeUnit_TopLevel:
 	@FSTTerminal(name="{Statement}") Statement :: StmtTL;
 	
 @FSTTerminal(name="{<IDENTIFIER>}")
-Id: <IDENTIFIER>;
+Id:  <IDENTIFIER>;
+
 
 CodeUnit_InBlock:
 	LL(2) PPIfDef_BlockLevel :: IfDefBL |
@@ -412,9 +413,10 @@ CodeUnit_InBlock:
 	LL(1) Block :: Blck |
 	Statement :: Stmt;	
 
+
 @FSTTerminal(name="{TOSTRING}")		
 Statement:
-	(AnyStmtToken)* ";" @!;
+	(AnyStmtToken)*  ";" @!;
 	
 IfStatement:
 	"if" "(" JAVATOKEN(findEndCB) BlockOrSingleStatement [ LL(1) ElseBlock ];
@@ -452,7 +454,8 @@ PPDefineStatement:
 	LL(2) "#" "define" JAVATOKEN(findLineEnd)@! |
 	LL(2) "#" "undef" JAVATOKEN(findLineEnd)@!;
 
-@FSTExportName("{TOSTRING}")	
+@FSTExportName("{IfDefLine}")
+@FSTNonTerminal
 PPIfDef_TopLevel:
 	IfDefLine  @+
 	Sequence_CodeUnit_TopLevel
@@ -467,17 +470,23 @@ PPIfDef_BlockLevel:
 	[ LL(2)@- "#" "else" @+! Sequence_CodeUnit_InBlock @!] 
 	@-"#" "endif"@!;
 
-@FSTExportName("{TOSTRING}")
+//@FSTExportName("{TOSTRING}")
 PPOtherIgnore:
 	"line" | "pragma" |"error";
 	
+@FSTExportName("{TOSTRING}")
+//@FSTTerminal(compose="CMethodOverriding")	
 IfDefLine:
 	LL(2) "#" "ifdef" <IDENTIFIER> @!| LL(2)  "#" "ifndef" <IDENTIFIER>@! | "#" "if" JAVATOKEN(findLineEnd)@!;
+	
 IfElseIf:
 	LL(2) "#" "elif" <NONE> | "#" "elsif"<NONE>;
+	
 IfElseIf_BlockLevel:
 	@- IfElseIf JAVATOKEN(findLineEnd) @+!
 	Sequence_CodeUnit_InBlock;
+	
+
 IfElseIf_TopLevel:
 	IfElseIf JAVATOKEN(findLineEnd)@!
 	Sequence_CodeUnit_TopLevel;
@@ -536,7 +545,7 @@ Cast:
 	
 AnyTypeDefToken: LL(1) "{" <NONE> | "}" | AnyStmtToken;
 	
-AnyStmtToken: <IDENTIFIER> | <LITERAL>  | <OTHER> | "," | "|" | "<" | ">" | "(" | ")" | 
+AnyStmtToken:  <IDENTIFIER> | <LITERAL>  | <OTHER> | "," | "|" | "<" | ">" | "(" | ")" | 
 	Block | "if" | "else" | "for" | "while" | LL(3) EnumBlock | "enum" | "*" |
 	LL("\"=\" [Cast()]\"{\"") BlockAssignment | "=" | ":"  
 	| Modifier  

--- a/fstgen/test/capprox_fst.gcide
+++ b/fstgen/test/capprox_fst.gcide
@@ -393,7 +393,7 @@ CodeUnit_TopLevel:
 	@FSTTerminal(name="{TypeDef}") TypeDef :: TypeDef_ |
 	@FSTTerminal(name="{ExternDecl}") LL(3) ExternDecl :: ExternDec |
 	@FSTNonTerminal(name="{Id}") LL(3) "struct" Id "{" (Statement)* "}" ";" :: StructDec |
-	@FSTTerminal(name="{Statement}",compose="FieldOverriding") Statement :: StmtTL;
+	@FSTTerminal(name="{Statement}") Statement :: StmtTL;
 	
 @FSTTerminal(name="{<IDENTIFIER>}")
 Id:  <IDENTIFIER>;
@@ -476,21 +476,33 @@ PPOtherIgnore:
 	
 
 @FSTNonTerminal(name="{IfDefHeader}-{IfDefBlock}")
+//@FSTNonTerminal
 IfDefTopLevelBlock:
-	LL(2) IfDefHeader IfDefBlock @! 
+	LL(2) IfDefHeader @! IfDefBlock @! 
 	| LL(2)  "#" "ifndef" Id@! IfDefBlock 
-	| "#" "if" JAVATOKEN(findLineEnd)@! IfDefBlock;
+	| LL(2) IfDefineHeader /*JAVATOKEN(findLineEnd)*/ @! IfDefBlock;
 
 @FSTExportName("{Id}")
 @FSTNonTerminal
 IfDefBlockLevelBlock:
-	LL(2) IfDefHeader IfDefInBlock @! 
+	LL(2) IfDefHeader @! IfDefInBlock @! 
 	| LL(2)  "#" "ifndef" Id@! IfDefInBlock 
 	| "#" "if" JAVATOKEN(findLineEnd)@! IfDefInBlock;
 	
 @FSTExportName("{Id}")
 IfDefHeader:
 	"#ifdef" Id;
+
+IfDefineHeader:
+	"#" "if" JAVATOKEN(findLineEnd);
+	//| LL(2) "#" "if" (AnyStmtToken)* "||" (AnyStmtToken)*; 
+
+@FSTNonTerminal
+IfDefine:
+	/*"defined(" Id ")"
+	| LL(2) "!defined(" Id ")"
+	| LL(3)*/ (AnyStmtToken)*;
+
 
 @FSTNonTerminal(name="{CodeUnit_TopLevel}")
 IfDefBlock:
@@ -574,13 +586,10 @@ Cast:
 	
 AnyTypeDefToken: LL(1) "{" <NONE> | "}" | AnyStmtToken;
 
-@FSTExportName("{TOSTRING}")
-StarSign:
-	"*";
 
 @FSTExportName("{<IDENTIFIER>}")
 AnyStmtToken:  <IDENTIFIER> | <LITERAL>  | <OTHER> | "," | "|" | "<" | ">" | "(" | ")" | 
-	Block | "if" | "else" | "for" | "while" | LL(3) EnumBlock | "enum" | StarSign  |
+	Block | "if" | "else" | "for" | "while" | LL(3) EnumBlock | "enum" | "*"  |
 	LL("\"=\" [Cast()]\"{\"") BlockAssignment | "=" | ":"  
 	| Modifier  
 	|  "ifdef" | "ifndef" | "define" | "include" | "elif" | "elsif" | PPOtherIgnore

--- a/fstgen/test/capprox_fst.gcide
+++ b/fstgen/test/capprox_fst.gcide
@@ -393,7 +393,7 @@ CodeUnit_TopLevel:
 	@FSTTerminal(name="{TypeDef}") TypeDef :: TypeDef_ |
 	@FSTTerminal(name="{ExternDecl}") LL(3) ExternDecl :: ExternDec |
 	@FSTNonTerminal(name="{Id}") LL(3) "struct" Id "{" (Statement)* "}" ";" :: StructDec |
-	@FSTTerminal(name="{Statement}") Statement :: StmtTL;
+	@FSTTerminal(name="{Statement}",compose="FieldOverriding") Statement :: StmtTL;
 	
 @FSTTerminal(name="{<IDENTIFIER>}")
 Id:  <IDENTIFIER>;

--- a/fstgen/test/capprox_fst.gcide
+++ b/fstgen/test/capprox_fst.gcide
@@ -463,11 +463,12 @@ PPIfDef_TopLevel:
 	@- "#endif" @!;
 
 @FSTExportName("{IfDefBlockLevelBlock}")
+@FSTNonTerminal
 PPIfDef_BlockLevel:
 	IfDefBlockLevelBlock @+	
 	(LL(2) IfElseIf_BlockLevel)*
-	[ LL(2)@- "#" "else" @+! IfDefBlock @!]
-	@-"#" "endif"@!;
+	[ LL(2)@- "#" "else" @+! IfDefInBlock @!]
+	@-"#endif"@!;
 
 //@FSTExportName("{TOSTRING}")
 PPOtherIgnore:
@@ -479,6 +480,13 @@ IfDefTopLevelBlock:
 	LL(2) IfDefHeader IfDefBlock @! 
 	| LL(2)  "#" "ifndef" Id@! IfDefBlock 
 	| "#" "if" JAVATOKEN(findLineEnd)@! IfDefBlock;
+
+@FSTExportName("{Id}")
+@FSTNonTerminal
+IfDefBlockLevelBlock:
+	LL(2) IfDefHeader IfDefInBlock @! 
+	| LL(2)  "#" "ifndef" Id@! IfDefInBlock 
+	| "#" "if" JAVATOKEN(findLineEnd)@! IfDefInBlock;
 	
 @FSTExportName("{Id}")
 IfDefHeader:
@@ -488,10 +496,17 @@ IfDefHeader:
 IfDefBlock:
 	(LL(2) CodeUnit_TopLevel @!)*;
 	
-@FSTExportName("{Id}")
+@FSTNonTerminal(name="{CodeUnit_InBlock}")
+IfDefInBlock:
+   (LL(2) CodeUnit_InBlock @! )*;
+   
+/*@FSTExportName("{Id}")
 @FSTNonTerminal
 IfDefBlockLevelBlock:
 	LL(2) "#ifdef" Id Sequence_CodeUnit_InBlock @! | LL(2)  "#" "ifndef" Id@! Sequence_CodeUnit_InBlock | "#" "if" JAVATOKEN(findLineEnd)@! Sequence_CodeUnit_InBlock;
+*/
+
+
 
 IfElseIf:
 	LL(2) "#" "elif" <NONE> | "#" "elsif"<NONE>;


### PR DESCRIPTION
This pull request updates the capprox grammar of featurehouse to support c pre-processor composition.

For the purpose of scientific project we needed to update the c approximated grammar to support the composition of c-pre-processor code. The new approach supports the possibility of using the normal c-pre-processor for programming and also to refine ifdefs/if etc. This approach is only supported with the Antenna-Composer for pre-processing.