### PR TITLE
Change external line based merge tool to git merge-file.

### DIFF
--- a/INSTALLATION
+++ b/INSTALLATION
@@ -9,7 +9,7 @@ all dependencies between the projects are allready set.
 
 requirements:
   - openjdk jre
-  - rcs (ubuntu: aptitude install rcs)
+  - git (ubuntu: apt-get install git)
   - R (for evaluation of fstmerge results;
     ubuntu: aptitude install r-recommended)
 

--- a/fstmerge/merger/LineBasedMerger.java
+++ b/fstmerge/merger/LineBasedMerger.java
@@ -91,9 +91,9 @@ public class LineBasedMerger implements MergerInterface {
 
 	        String mergeCmd = ""; 
 	        if(System.getProperty("os.name").contains("Windows"))
-	        	mergeCmd = "C:\\Programme\\cygwin\\bin\\merge.exe -q -p " + "\"" + fileVar1.getPath() + "\"" + " " + "\"" + fileBase.getPath() + "\"" + " " + "\"" + fileVar2.getPath() + "\"";// + " > " + fileVar1.getName() + "_output";
+	        	mergeCmd = "C:\\Programme\\cygwin\\bin\\git.exe --merge-file -q -p " + "\"" + fileVar1.getPath() + "\"" + " " + "\"" + fileBase.getPath() + "\"" + " " + "\"" + fileVar2.getPath() + "\"";// + " > " + fileVar1.getName() + "_output";
 	        else
-	        	mergeCmd = "merge -q -p " + fileVar1.getPath() + " " + fileBase.getPath() + " " + fileVar2.getPath();// + " > " + fileVar1.getName() + "_output";
+	        	mergeCmd = "git merge-file -q -p " + fileVar1.getPath() + " " + fileBase.getPath() + " " + fileVar2.getPath();// + " > " + fileVar1.getName() + "_output";
 	        Runtime run = Runtime.getRuntime();
 			Process pr = run.exec(mergeCmd);
 

--- a/fstmerge/scripts/createMerge.sh
+++ b/fstmerge/scripts/createMerge.sh
@@ -15,6 +15,6 @@ do
 	mkdir -p `dirname $mergeDir$stripDir`
 	
 	#apply merge	
-	merge -p -q $f $2$stripDir $3$stripDir > $mergeDir$stripDir
+	git merge-file -p -q $f $2$stripDir $3$stripDir > $mergeDir$stripDir
 	#echo $f $2$stripDir $3$stripDir $mergeDir$stripDir	
 done

--- a/fstmerge/scripts/createMerge3.sh
+++ b/fstmerge/scripts/createMerge3.sh
@@ -159,7 +159,7 @@ iterateRight() {
 
 mergeFiles() {
 	# applyMerge
-	merge -p -q $1 $2 $3 > $4
+	git merge-file -p -q $1 $2 $3 > $4
 }
 
 createEmptyFile() {


### PR DESCRIPTION
Git is way more common than RCS by now, so it is more likely to be
installed on modern operating systems. With 'merge-file', it provides a
minimal clone of RCS merge. Therefore, we can get rid of the
additional dependency to the rather ancient RCS.

I also looked into using 'diff3 --merge -E', but found that it uses an
inferior merge algorithm that produces larger conflicts.