### PR TITLE
Migrate travis to container-based infrastracture.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     apt:
         packages:
             - ant
-            - rcs
+            - git
 
 #ant test is the default target, but I want to make it explicit
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
+sudo: required
+
 language: java
-install: ant jar
+
+jdk:
+    - oraclejdk7
+
+addons:
+    apt:
+        packages:
+            - ant
+            - rcs
+
 #ant test is the default target, but I want to make it explicit
-script: ant test
+script:
+    - ant test


### PR DESCRIPTION
Currently, a warning message is shown in travis, notifying that the featurehouse builds run on their legacy infrastructure. This pull request migrates to their new, container-based infrastructure.

At first, I hoped that this would also fix the random kills from the travis host system (error code 137, seems to be related to resource consumption), as the travis documentation states that the new infrastructure has higher resource limits. But unfortunately, the kills still occur.