### PR TITLE
Fix: Set 'sudo: false' in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 
 language: java
 


### PR DESCRIPTION
sudo is actually not required for our builds. I suspect this to be the
reason why we somehow still run on the travis legacy infrastructure and
experience random kills with our travis builds.

My travis build history after this change is currently fine so far.