### PR TITLE
Added command line option to avoid creating nested build folder

### DIFF
--- a/fstcomp/composer/CmdLineInterpreter.java
+++ b/fstcomp/composer/CmdLineInterpreter.java
@@ -23,7 +23,8 @@ public class CmdLineInterpreter {
 	public static final String INPUT_OPTION_FILE_OUTPUT = "--write";
 
 	public static final String INPUT_OPTION_OUTPUT_DIRECTORY = "--output-directory";
-
+	public static final String INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR = "--create-config-output-dir";
+	
 	public static final String INPUT_OPTION_CONTRACT_STYLE = "--contract-style";
 
 	public static final String INPUT_OPTION_RESOLVE_REFERENCES = "--resolve-references";
@@ -49,6 +50,7 @@ public class CmdLineInterpreter {
 	public String equationBaseDirectoryName;
 
 	public String outputDirectoryName = null;
+	public static boolean CREATE_FEATURE_OUTPUT_DIR = true;
 
 	public String contract_style = "none";
 
@@ -163,6 +165,15 @@ public class CmdLineInterpreter {
 					}
 				} else if (args[i].equals(INPUT_OPTION_EXPORT_ROLES_IN_JSON_FORMAT)) {
 					exportRolesInJSONformat=true;
+				} else if (args[i].equals(INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR)) {
+					i++;
+					try {
+						CREATE_FEATURE_OUTPUT_DIR = Boolean.parseBoolean(args[i]);
+					} catch (Exception e) {
+						System.out.println("Error occured option: "
+								+ INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR);
+						errorOccured = true;
+					}
 				} else {
 					errorOccured = true;
 				}

--- a/fstcomp/composer/CmdLineInterpreter.java
+++ b/fstcomp/composer/CmdLineInterpreter.java
@@ -23,7 +23,7 @@ public class CmdLineInterpreter {
 	public static final String INPUT_OPTION_FILE_OUTPUT = "--write";
 
 	public static final String INPUT_OPTION_OUTPUT_DIRECTORY = "--output-directory";
-	public static final String INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR = "--create-config-output-dir";
+	public static final String INPUT_OPTION_NO_CONFIG_OUTPUT_DIR = "--no-config-output-dir";
 	
 	public static final String INPUT_OPTION_CONTRACT_STYLE = "--contract-style";
 
@@ -165,15 +165,8 @@ public class CmdLineInterpreter {
 					}
 				} else if (args[i].equals(INPUT_OPTION_EXPORT_ROLES_IN_JSON_FORMAT)) {
 					exportRolesInJSONformat=true;
-				} else if (args[i].equals(INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR)) {
-					i++;
-					try {
-						CREATE_FEATURE_OUTPUT_DIR = Boolean.parseBoolean(args[i]);
-					} catch (Exception e) {
-						System.out.println("Error occured option: "
-								+ INPUT_OPTION_CREATE_CONFIG_OUTPUT_DIR);
-						errorOccured = true;
-					}
+				} else if (args[i].equals(INPUT_OPTION_NO_CONFIG_OUTPUT_DIR)) {
+					CREATE_FEATURE_OUTPUT_DIR = false;
 				} else {
 					errorOccured = true;
 				}

--- a/fstcomp/printer/FeaturePrintVisitor.java
+++ b/fstcomp/printer/FeaturePrintVisitor.java
@@ -2,6 +2,7 @@ package printer;
 import java.io.File;
 import java.util.LinkedList;
 
+import composer.CmdLineInterpreter;
 import de.ovgu.cide.fstgen.ast.FSTNode;
 import de.ovgu.cide.fstgen.ast.FSTNonTerminal;
 
@@ -53,13 +54,19 @@ public class FeaturePrintVisitor {
 		visit(root, null, null, null);
 	}
 	
+	static boolean createConfigurationFolder = false;
+	
 	private void visit(FSTNonTerminal nonterminal, File featurePath, File folderPath, File oldFolderPath) throws PrintVisitorException {
 		if(nonterminal != null) {
 			if(nonterminal.getType().equals("Feature")) {
-				StringBuffer sb = new StringBuffer(getExpressionName());
-				sb.setLength(sb.lastIndexOf("."));
-				sb.delete(0, sb.lastIndexOf(File.separator) + 1);
-				featurePath = new File(getWorkingDir() + File.separator + sb.toString());
+				if (CmdLineInterpreter.CREATE_FEATURE_OUTPUT_DIR) {
+					StringBuffer sb = new StringBuffer(getExpressionName());
+					sb.setLength(sb.lastIndexOf("."));
+					sb.delete(0, sb.lastIndexOf(File.separator) + 1);
+					featurePath = new File(getWorkingDir() + File.separator + sb.toString());
+				} else {
+					featurePath = new File(getWorkingDir());
+				}
 				featurePath.mkdir();
 				folderPath = featurePath;
 				for(FSTNode child : nonterminal.getChildren()) {

--- a/fstcomp/printer/FeaturePrintVisitor.java
+++ b/fstcomp/printer/FeaturePrintVisitor.java
@@ -54,8 +54,6 @@ public class FeaturePrintVisitor {
 		visit(root, null, null, null);
 	}
 	
-	static boolean createConfigurationFolder = false;
-	
 	private void visit(FSTNonTerminal nonterminal, File featurePath, File folderPath, File oldFolderPath) throws PrintVisitorException {
 		if(nonterminal != null) {
 			if(nonterminal.getType().equals("Feature")) {


### PR DESCRIPTION
FH creates by default a nested folder in src, i.e., src/configname
To avoid this I introduced a new cmd line option